### PR TITLE
API CHANGE: let lookup_asn return a AS-prefixed string

### DIFF
--- a/mkmmdb-client.cpp
+++ b/mkmmdb-client.cpp
@@ -83,6 +83,6 @@ int main(int, char **argv) {
     if (!ok) exit(EXIT_FAILURE);                           \
   } while (0)
   LOOKUP(country_db, cc);
-  LOOKUP(asn_db, asn);
+  LOOKUP(asn_db, asn2);
   LOOKUP(asn_db, org);
 }

--- a/mkmmdb.hpp
+++ b/mkmmdb.hpp
@@ -46,10 +46,11 @@ class Handle {
   bool lookup_cc(const std::string &ip, std::string &cc,
                  std::vector<std::string> &logs) noexcept;
 
-  /// lookup_asn is like lookup_cc except that it looks up the autonomous
-  /// system number (ASN), which will be saved into the @p cc string.
-  bool lookup_asn(const std::string &ip, std::string &asn,
-                  std::vector<std::string> &logs) noexcept;
+  /// lookup_asn2 is like lookup_cc except that it looks up the autonomous
+  /// system number (ASN), which will be saved into the @p cc string. Please,
+  /// note that the ASN will be in the format `AS<number>`.
+  bool lookup_asn2(const std::string &ip, std::string &asn,
+                   std::vector<std::string> &logs) noexcept;
 
   /// lookup_org is like lookup_cc except that it looks up the autonomous
   /// system organization name, which will be saved into @p org.
@@ -271,12 +272,15 @@ bool Handle::Impl::finish_lookup_asn(
   if (!ok) {
     return false;
   }
-  asn = std::to_string(data.uint32);
+  // Historical note: since version v0.4.0, the ASN that we return is
+  // prefixed with `"AS"`. For this reason we did change the name of
+  // the publicly exposed API from `lookup_asn` to `lookup_asn2`.
+  asn = std::string{"AS"} + std::to_string(data.uint32);
   return true;
 }
 
-bool Handle::lookup_asn(const std::string &ip, std::string &asn,
-                        std::vector<std::string> &logs) noexcept {
+bool Handle::lookup_asn2(const std::string &ip, std::string &asn,
+                         std::vector<std::string> &logs) noexcept {
   return impl->lookup(
       ip, logs, [&](MMDB_entry_s *entry) {
         return impl->finish_lookup_asn(entry, asn, logs);

--- a/tests.cpp
+++ b/tests.cpp
@@ -31,7 +31,7 @@ TEST_CASE("When MMDB_lookup_string fails with mmdb_error") {
         mk::mmdb::Handle handle;
         std::string asn;
         REQUIRE(handle.open("asn.mmdb", logs) == true);
-        REQUIRE(handle.lookup_asn("8.8.8.8", asn, logs) == false);
+        REQUIRE(handle.lookup_asn2("8.8.8.8", asn, logs) == false);
       });
 }
 
@@ -71,7 +71,7 @@ TEST_CASE("When lookup_cc fails because MMDB provides us a bad value") {
       });
 }
 
-TEST_CASE("When lookup_asn fails because MMDB provides us a bad value") {
+TEST_CASE("When lookup_asn2 fails because MMDB provides us a bad value") {
   MKMOCK_WITH_ENABLED_HOOK(
       finish_lookup_asn_check, false,
       {
@@ -79,7 +79,7 @@ TEST_CASE("When lookup_asn fails because MMDB provides us a bad value") {
         mk::mmdb::Handle handle;
         std::string asn;
         REQUIRE(handle.open("asn.mmdb", logs) == true);
-        REQUIRE(handle.lookup_asn("8.8.8.8", asn, logs) == false);
+        REQUIRE(handle.lookup_asn2("8.8.8.8", asn, logs) == false);
       });
 }
 


### PR DESCRIPTION
This is more natural. Because of the API change, I've renamed
the method, from lookup_asn to lookup_asn2. This breaks the
build, so one needs to think and adapt the code. In turn this
reduces the probability of screwing up.